### PR TITLE
VAP-9999 Fix cutoff error

### DIFF
--- a/src/hooks/useVapiChat.ts
+++ b/src/hooks/useVapiChat.ts
@@ -127,9 +127,9 @@ export const handleStreamChunk = (
 
     // Since we pre-allocated, we know the index is always valid
     if (assistantMessageIndexRef.current !== null) {
+      const targetIndex = assistantMessageIndexRef.current!;
       setMessages((prev) => {
         const newMessages = [...prev];
-        const targetIndex = assistantMessageIndexRef.current!;
 
         if (targetIndex < newMessages.length) {
           newMessages[targetIndex] = {


### PR DESCRIPTION
Race condition that was randomly cutting off assistant messages. Basically, we were checking if assistantMessageIndexRef.current wasn't null, but then reading it again inside an async React state callback. Between those two moments, the stream could complete and set it to null.

<img width="1126" height="475" alt="image" src="https://github.com/user-attachments/assets/7c53fd3a-29d6-4296-938d-57d39119d25e" />
