### PR TITLE
VAP-999 Add end chat button and logic

### DIFF
--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -44,6 +44,7 @@ export interface VapiWidgetProps {
   // Chat Configuration
   chatFirstMessage?: string;
   chatPlaceholder?: string;
+  chatEndMessage?: string;
 
   // Voice Configuration
   voiceShowTranscript?: boolean;
@@ -153,6 +154,8 @@ export interface WidgetHeaderProps {
   mainLabel: string;
   onClose: () => void;
   onReset: () => void;
+  onChatComplete: () => void;
+  showEndChatButton?: boolean;
   colors: ColorScheme;
   styles: StyleConfig;
 }

--- a/src/components/widget/WidgetHeader.tsx
+++ b/src/components/widget/WidgetHeader.tsx
@@ -13,6 +13,8 @@ const WidgetHeader: React.FC<WidgetHeaderProps> = ({
   mainLabel,
   onClose,
   onReset,
+  onChatComplete,
+  showEndChatButton,
   colors,
   styles,
 }) => {
@@ -68,6 +70,15 @@ const WidgetHeader: React.FC<WidgetHeaderProps> = ({
         </div>
       </div>
       <div className="flex items-center space-x-2">
+        {showEndChatButton !== false && (
+          <button
+            onClick={onChatComplete}
+            className={`text-red-600 text-sm font-medium px-2 py-1 border border-transparent hover:border-red-600 rounded-md transition-colors`}
+            title="End Chat"
+          >
+            End Chat
+          </button>
+        )}
         <button
           onClick={onReset}
           className={`w-8 h-8 rounded-full flex items-center justify-center transition-all}`}

--- a/src/hooks/useVapiWidget.ts
+++ b/src/hooks/useVapiWidget.ts
@@ -119,7 +119,7 @@ export const useVapiWidget = ({
   }, []);
 
   const sendMessage = useCallback(
-    async (text: string) => {
+    async (text: string, sessionEnd: boolean = false) => {
       // In hybrid mode, switch to chat and clear all conversations only if switching from voice
       if (mode === 'hybrid') {
         if (voice.isCallActive) {
@@ -132,7 +132,7 @@ export const useVapiWidget = ({
         }
         setActiveMode('chat');
       }
-      await chat.sendMessage(text);
+      await chat.sendMessage(text, sessionEnd);
     },
     [mode, chat, voice, activeMode]
   );

--- a/src/utils/vapiChatClient.ts
+++ b/src/utils/vapiChatClient.ts
@@ -12,6 +12,7 @@ export interface VapiChatMessage {
   assistantOverrides?: AssistantOverrides;
   sessionId?: string;
   stream?: boolean;
+  sessionEnd?: boolean;
 }
 
 export interface VapiChatStreamChunk {


### PR DESCRIPTION
Added and end chat button that sends a message to mark a session as complete, triggering the webhook and End of Chat report. 

To test, set up session-update webhook on assistant, chat with an assistant for atleast one message in the widget, and end the chat to receive the completed webhook