### PR TITLE
VAP-0000 Fix CSS injection

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -18,7 +18,21 @@
   -webkit-text-size-adjust: 100%;
   -moz-tab-size: 4;
   tab-size: 4;
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    'Noto Sans',
+    sans-serif,
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
+    'Noto Color Emoji';
   font-feature-settings: normal;
   font-variation-settings: normal;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,12 +1,26 @@
-@tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Custom base styles for the library */
-@layer base {
-  * {
-    box-sizing: border-box;
-  }
+/* Scoped base styles only for the widget */
+.vapi-widget-wrapper {
+  box-sizing: border-box;
+}
+
+.vapi-widget-wrapper *,
+.vapi-widget-wrapper *::before,
+.vapi-widget-wrapper *::after {
+  box-sizing: border-box;
+}
+
+/* Reset only within widget to prevent inheritance from host page */
+.vapi-widget-wrapper {
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  -moz-tab-size: 4;
+  tab-size: 4;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-feature-settings: normal;
+  font-variation-settings: normal;
 }
 
 /* Hide scrollbar completely */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  important: '.vapi-widget-wrapper',
+  
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   important: '.vapi-widget-wrapper',
-  
+
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
# Fix: Isolate Widget CSS to Prevent Host Page Style Conflicts

## Problem
Widget's global CSS (especially Tailwind base reset) was injecting into host pages and overriding their styles, causing conflicts and breaking host page layouts.

## Solution
Implemented **selector-based CSS scoping**. All widget styles are now scoped to `.vapi-widget-wrapper` container.

### CSS Generation
**Before:** `.flex { display: flex; }` (global, affects host page)  
**After:** `.vapi-widget-wrapper .flex { display: flex !important; }` (scoped, isolated)