### PR TITLE
Add license metadata to package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Vapi Client React SDK",
   "version": "0.1.1",
   "type": "module",
+    "license": "MIT",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Adds MIT license metadata to package.json, matching the repository LICENSE file and making the published package metadata clearer for npm consumers and license/compliance scanners.

Verification:
- npm metadata for @vapi-ai/client-sdk-react@0.1.1 currently has an empty license field.
- Repository LICENSE is MIT.
- Diff is package metadata only: one license field added.